### PR TITLE
E kbranch

### DIFF
--- a/cmp_viewer/ImageViewer.py
+++ b/cmp_viewer/ImageViewer.py
@@ -9,10 +9,13 @@ from cmp_viewer.rgb import *
 from cmp_viewer.clusterImgSelect import *
 from cmp_viewer.Cluster import *
 import nornir_imageregistration
+import datetime
 from cmp_viewer import models
 from PIL import Image
 import typing
 import numpy as np
+import re
+import csv
 
 from PyQt5.QtWidgets import QApplication, QGraphicsScene, QGraphicsView
 from PyQt5.QtWidgets import QMainWindow
@@ -33,7 +36,7 @@ from PyQt5.QtWidgets import QHBoxLayout
 from PyQt5.QtWidgets import QListView
 from PyQt5.QtWidgets import QListWidget
 from PyQt5.QtWidgets import QComboBox
-from PyQt5.QtWidgets import QSlider, QProgressDialog, QListWidgetItem, QColorDialog, QMenu
+from PyQt5.QtWidgets import QSlider, QProgressDialog, QListWidgetItem, QColorDialog, QMenu, QInputDialog
 from PyQt5 import QtWidgets
 from PyQt5 import QtGui
 from PyQt5.QtGui import QPixmap, qRgb
@@ -61,6 +64,16 @@ class ImageViewerUi(QMainWindow):
     last_grayscale_index = None  # Track the last grayscale image index
     last_rgb_state = None  # Track the last RGB state
     overlay_items = {}  # Track overlay items in the scene by cluster ID
+    _cluster_names = {}  # Optional custom names for clusters (cluster_id -> name)
+    _last_selected_roi_cluster_id = None  # Tracks the ROI cluster id used for the last clustering (if any)
+    _last_selected_roi_name = None  # Tracks the ROI cluster display name used for the last clustering (if any)
+
+    # Saved/Protected masks (session-only)
+    _saved_masks = {}  # saved_id -> (mask: np.ndarray[bool], color: QColor, name: str)
+    _saved_visible = set()  # saved_id items currently visible
+    _next_saved_id = 1  # incrementing ID for saved masks
+    saved_mask_overlays = {}  # cache for saved mask overlays
+    saved_overlay_items = {}  # graphics items for saved overlays
     """View Gui"""
 
     def __init__(self, starting_images_folder=None):
@@ -188,28 +201,31 @@ class ImageViewerUi(QMainWindow):
         self.generalLayout.addWidget(self.display, 1)  # Stretch factor of 1 makes it expand
 
     def _createIterativeClusteringControls(self):
-        self.iterativeClusterBox = QtWidgets.QGroupBox('Iterative Clustering')
+        self.iterativeClusterBox = QtWidgets.QGroupBox('Cluster Masks')
         self.iterativeClusterLayout = QVBoxLayout()
         self.iterativeClusterBox.setLayout(self.iterativeClusterLayout)
 
-        self.subClustersInput = QLineEdit()
-        self.subClustersInput.setPlaceholderText("Number of sub-clusters")
-        self.iterativeClusterLayout.addWidget(self.subClustersInput)
-
-        self.iterativeClusterButton = QPushButton("Run Iterative Clustering")
-        self.iterativeClusterButton.clicked.connect(self.run_iterative_clustering)
-        self.iterativeClusterLayout.addWidget(self.iterativeClusterButton)
-
-        self.mergeClusterButton = QPushButton("Merge Selected Clusters")
-        self.mergeClusterButton.clicked.connect(self.merge_selected_clusters)
-        self.iterativeClusterLayout.addWidget(self.mergeClusterButton)
 
         self.clusterVisibilityList = QListWidget()
         self.clusterVisibilityList.setMinimumHeight(100)
         self.clusterVisibilityList.setContextMenuPolicy(Qt.CustomContextMenu)
         self.clusterVisibilityList.customContextMenuRequested.connect(self.show_cluster_context_menu)
-        self.iterativeClusterLayout.addWidget(QLabel("Cluster Mask Visibility (Check to select for reclustering)"))
+        self.iterativeClusterLayout.addWidget(QLabel("Cluster Mask Visibility (Live)"))
         self.iterativeClusterLayout.addWidget(self.clusterVisibilityList)
+
+        # Saved Masks panel
+        self.savedMasksList = QListWidget()
+        self.savedMasksList.setMinimumHeight(100)
+        self.savedMasksList.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.savedMasksList.customContextMenuRequested.connect(self.show_saved_context_menu)
+        self.savedMasksList.itemChanged.connect(self.toggle_saved_visibility)
+        self.iterativeClusterLayout.addWidget(QLabel("Saved Masks (Protected)"))
+        self.iterativeClusterLayout.addWidget(self.savedMasksList)
+
+        # Merge Selected Clusters button (restored)
+        self.mergeClusterButton = QPushButton("Merge Selected Clusters")
+        self.mergeClusterButton.clicked.connect(self.merge_selected_clusters)
+        self.iterativeClusterLayout.addWidget(self.mergeClusterButton)
 
         self.opacitySlider = QSlider(Qt.Horizontal)
         self.opacitySlider.setMinimum(0)
@@ -231,9 +247,14 @@ class ImageViewerUi(QMainWindow):
         self.exportMasksButton.clicked.connect(self.export_cluster_masks)
         self.iterativeClusterLayout.addWidget(self.exportMasksButton)
 
-        self.undoButton = QPushButton("Undo Clustering")
-        self.undoButton.clicked.connect(self.undo_clustering)
-        self.iterativeClusterLayout.addWidget(self.undoButton)
+        self.exportSavedMasksButton = QPushButton("Export Saved Masks")
+        self.exportSavedMasksButton.clicked.connect(self.export_saved_masks)
+        self.iterativeClusterLayout.addWidget(self.exportSavedMasksButton)
+
+        # New: Export intensity stats under a Saved Mask
+        self.exportIntensityStatsButton = QPushButton("Export Intensity Stats (Saved Mask)")
+        self.exportIntensityStatsButton.clicked.connect(self.export_intensity_stats)
+        self.iterativeClusterLayout.addWidget(self.exportIntensityStatsButton)
 
         # Add to the left controls layout instead of directly to generalLayout
         self.leftControlsLayout.addWidget(self.iterativeClusterBox)
@@ -459,13 +480,20 @@ class ImageViewerUi(QMainWindow):
         self.last_grayscale_index = None
         self.last_rgb_state = None
         self.overlay_items.clear()
+        self._cluster_names.clear()
+        # Clear saved masks state
+        self._saved_masks.clear()
+        self._saved_visible.clear()
+        self.saved_mask_overlays.clear()
+        self.saved_overlay_items.clear()
         if self.clusterview:
             self.clusterview.undo_stack.clear()
         self._image_set = models.ImageSet()
         self.displayImage.clear()
 
-        self.subClustersInput.clear()
         self.clusterVisibilityList.clear()
+        if hasattr(self, 'savedMasksList'):
+            self.savedMasksList.clear()
         self.opacitySlider.setValue(self._mask_opacity)
         self.exportFormatCombo.setCurrentText("PNG")
 
@@ -527,10 +555,17 @@ class ImageViewerUi(QMainWindow):
             self.clusterview.undo_stack.clear()
         self._image_set = models.ImageSet()
         self.displayImage.clear()
+        self._cluster_names.clear()
+        # Clear saved masks state
+        self._saved_masks.clear()
+        self._saved_visible.clear()
+        self.saved_mask_overlays.clear()
+        self.saved_overlay_items.clear()
 
         # Clear cluster-related UI elements
-        self.subClustersInput.clear()
         self.clusterVisibilityList.clear()
+        if hasattr(self, 'savedMasksList'):
+            self.savedMasksList.clear()
         self.opacitySlider.setValue(self._mask_opacity)
         self.exportFormatCombo.setCurrentText("PNG")
 
@@ -573,12 +608,42 @@ class ImageViewerUi(QMainWindow):
             QMessageBox.warning(self, "Image Set Error", "The image set is not properly initialized. Please load images first.")
             return
 
-        select_dlg = ImageSelectDlg(self.fileNameList, self._image_set)
+        # Provide only Saved Masks as ROI choices per spec
+        available_masks = {}
+        names = {}
+        for sid, entry in self._saved_masks.items():
+            try:
+                mask, color, name = entry
+                available_masks[int(sid)] = (mask, color)
+                names[int(sid)] = name
+            except Exception:
+                continue
+
+        select_dlg = ImageSelectDlg(self.fileNameList, self._image_set, masks=available_masks, names=names)
         select_dlg.setModal(True)
 
         select_dlg.exec_()
 
-        self.clusterview = Cluster(self.fileNameList, self._image_set, select_dlg.selected_mask, self.on_cluster_callback)
+        # Prepare prior state and ROI for Cluster
+        base_labels = self.clusterview.labels if (self.clusterview is not None and hasattr(self.clusterview, 'labels')) else None
+        base_masks = self._masks if self._masks is not None else None
+        spatial_roi = getattr(select_dlg, 'selected_roi_mask', None)
+
+        # Capture the ROI display name from Saved Masks for naming
+        try:
+            roi_saved_id = getattr(select_dlg, 'selected_roi_cluster_id', None)
+            self._last_selected_roi_cluster_id = roi_saved_id
+            if roi_saved_id is not None and int(roi_saved_id) in self._saved_masks:
+                _, _, nm = self._saved_masks[int(roi_saved_id)]
+                self._last_selected_roi_name = nm
+            else:
+                self._last_selected_roi_name = None
+        except Exception:
+            self._last_selected_roi_cluster_id = None
+            self._last_selected_roi_name = None
+
+        self.clusterview = Cluster(self.fileNameList, self._image_set, select_dlg.selected_mask, self.on_cluster_callback,
+                                   base_labels=base_labels, base_masks=base_masks, spatial_roi=spatial_roi)
         self.clusterview.show()
 
     def on_cluster_callback(self, labels: NDArray[int], settings: typing.Any):
@@ -588,25 +653,86 @@ class ImageViewerUi(QMainWindow):
 
         # Use Cluster class to create the label image
         pillow_img = self.clusterview.create_label_image(labels, len(np.unique(labels)))
+
+        # Only proceed with mask/name updates if we recognize the settings type
         if isinstance(settings, KMeansSettings) or isinstance(settings, ISODATASettings):
+            # Determine if this was ROI-based or full-image clustering
+            # Use the Cluster widget's flag to avoid misclassifying ISODATA (which currently ignores ROI)
+            is_roi_run = bool(getattr(self.clusterview, '_last_run_was_roi', False))
+            roi_id = getattr(self, '_last_selected_roi_cluster_id', None)
+
+            # Previous and new cluster id sets
+            if is_roi_run:
+                prev_ids = set(self._masks.keys()) if isinstance(self._masks, dict) else set()
+            else:
+                # Full-image run: treat as fresh result; clear previous names to avoid mismatches
+                self._cluster_names.clear()
+                prev_ids = set()
+
+            new_ids = set(int(c) for c in np.unique(labels))
+
+            # Update masks from Cluster
             self._masks = self.clusterview.masks
+
+            # Preserve existing names for any cluster ids that persist (ROI runs only)
+            # and create names only for genuinely new ids
+            created_ids = [cid for cid in new_ids if cid not in prev_ids]
+
+            # Determine base name context if this was ROI-based reclustering
+            base_name = None
+            if is_roi_run:
+                # Prefer the captured ROI display name for stability
+                base_name = getattr(self, '_last_selected_roi_name', None)
+                if not base_name and roi_id is not None:
+                    base_name = self._cluster_names.get(int(roi_id), f"Cluster {int(roi_id)}")
+
+            # Build an algorithm label and proposed name format per new convention
+            if isinstance(settings, KMeansSettings):
+                algo_label = "Kmeans"
+            else:
+                algo_label = "ISODATA"
+
+            # Assign readable names to new cluster ids, avoiding overwrite; numbering uses actual cluster id
+            for cid in sorted(created_ids):
+                if cid in self._cluster_names:
+                    continue  # respect any pre-existing name
+                if base_name:
+                    proposed = f"{algo_label}({base_name}) Cluster {cid}"
+                else:
+                    proposed = f"{algo_label} Cluster {cid}"
+
+                # Ensure uniqueness among current names
+                unique_name = proposed
+                bump = 2
+                existing_names = set(self._cluster_names.values())
+                while unique_name in existing_names:
+                    unique_name = f"{proposed} [{bump}]"
+                    bump += 1
+
+                self._cluster_names[int(cid)] = unique_name
+
+            # Clear the ROI tracker after use
+            self._last_selected_roi_cluster_id = None
+
+            # Update UI
             self.update_cluster_visibility_list(labels)
             self.show_label_image(pillow_img, len(np.unique(labels)))
 
     def update_cluster_visibility_list(self, labels: NDArray[int]):
-        current_clusters = {int(item.text().split()[-1]) for i in range(self.clusterVisibilityList.count())
-                           for item in [self.clusterVisibilityList.item(i)]}
+        current_clusters = {self.clusterVisibilityList.item(i).data(Qt.UserRole) for i in range(self.clusterVisibilityList.count())}
         new_clusters = set(np.unique(labels))
 
         # Add new clusters
         for cluster_id in new_clusters - current_clusters:
-            item = QListWidgetItem(f"Cluster {cluster_id}")
+            display_name = self._cluster_names.get(int(cluster_id), f"Cluster {int(cluster_id)}")
+            item = QListWidgetItem(display_name)
+            item.setData(Qt.UserRole, int(cluster_id))
             item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
             item.setCheckState(Qt.Unchecked)
 
             # Set the background color to match the cluster color
-            if self._masks and cluster_id in self._masks:
-                _, color = self._masks.get(cluster_id)
+            if self._masks and int(cluster_id) in self._masks:
+                _, color = self._masks.get(int(cluster_id))
                 if color:
                     # Set background color to match cluster color
                     item.setBackground(color)
@@ -622,10 +748,10 @@ class ImageViewerUi(QMainWindow):
         # Remove obsolete clusters
         for i in reversed(range(self.clusterVisibilityList.count())):
             item = self.clusterVisibilityList.item(i)
-            cluster_id = int(item.text().split()[-1])
+            cluster_id = item.data(Qt.UserRole)
             if cluster_id not in new_clusters:
                 self.clusterVisibilityList.takeItem(i)
-                self._visible_clusters.discard(cluster_id)
+                self._visible_clusters.discard(int(cluster_id))
 
         self.clusterVisibilityList.itemChanged.connect(self.toggle_cluster_visibility)
         print(f"Updated cluster visibility list with {len(new_clusters)} clusters")
@@ -635,7 +761,7 @@ class ImageViewerUi(QMainWindow):
         Show a context menu for the cluster visibility list item at the given position.
 
         This method is called when the user right-clicks on an item in the cluster visibility list.
-        It creates a context menu with an option to change the color of the cluster.
+        It creates a context menu with options to change the color, rename, or save to Saved Masks.
 
         Args:
             position (QPoint): The position where the context menu should be displayed.
@@ -648,6 +774,8 @@ class ImageViewerUi(QMainWindow):
         # Create a context menu
         menu = QMenu()
         change_color_action = menu.addAction("Change Color")
+        rename_action = menu.addAction("Rename")
+        save_action = menu.addAction("Move to Saved Masks")
 
         # Show the menu and get the selected action
         action = menu.exec_(self.clusterVisibilityList.mapToGlobal(position))
@@ -655,6 +783,10 @@ class ImageViewerUi(QMainWindow):
         # Handle the selected action
         if action == change_color_action:
             self.change_cluster_color(item)
+        elif action == rename_action:
+            self.rename_cluster(item)
+        elif action == save_action:
+            self.save_live_cluster_to_saved(item)
 
     def change_cluster_color(self, item):
         """
@@ -669,8 +801,8 @@ class ImageViewerUi(QMainWindow):
         if self._masks is None or self.clusterview is None:
             return
 
-        # Get the cluster ID from the item text
-        cluster_id = int(item.text().split()[-1])
+        # Get the cluster ID from the item data
+        cluster_id = int(item.data(Qt.UserRole))
 
         # Get the current color
         mask, current_color = self._masks.get(cluster_id, (None, None))
@@ -699,40 +831,348 @@ class ImageViewerUi(QMainWindow):
         # Update the display
         self.show_label_image(self._clustered_image, self._num_labels)
 
+    def rename_cluster(self, item):
+        """
+        Prompt the user to rename the selected cluster and update UI/mapping.
+        """
+        if item is None:
+            return
+        cluster_id = int(item.data(Qt.UserRole))
+        current_name = self._cluster_names.get(cluster_id, item.text())
+        new_name, ok = QInputDialog.getText(self, "Rename Cluster", f"Enter a new name for Cluster {cluster_id}:", text=str(current_name))
+        if not ok:
+            return
+        new_name = new_name.strip()
+        if not new_name:
+            QMessageBox.warning(self, "Invalid Name", "Cluster name cannot be empty.")
+            return
+        # Save and update display text
+        self._cluster_names[cluster_id] = new_name
+        item.setText(new_name)
+
+    def save_live_cluster_to_saved(self, item: QListWidgetItem):
+        """Snapshot a live cluster mask into the Saved Masks list (session-only)."""
+        if item is None or self._masks is None:
+            return
+        try:
+            cluster_id = int(item.data(Qt.UserRole))
+        except Exception:
+            return
+        if cluster_id not in self._masks:
+            return
+        mask, color = self._masks[cluster_id]
+        # Deep copy the mask to prevent future mutation
+        mask_copy = mask.copy()
+        # Derive a name
+        base_name = self._cluster_names.get(cluster_id, f"Cluster {cluster_id}")
+        name = base_name
+        # Ensure uniqueness across saved masks
+        existing_names = {entry[2] for entry in self._saved_masks.values()}
+        if name in existing_names:
+            bump = 2
+            while f"{name} [{bump}]" in existing_names:
+                bump += 1
+            name = f"{name} [{bump}]"
+        # Assign new saved id
+        saved_id = int(self._next_saved_id)
+        self._next_saved_id += 1
+        # Store
+        self._saved_masks[saved_id] = (mask_copy, color, name)
+        # Add to UI list
+        saved_item = QListWidgetItem(name)
+        saved_item.setData(Qt.UserRole, int(saved_id))
+        saved_item.setFlags(saved_item.flags() | Qt.ItemIsUserCheckable)
+        saved_item.setCheckState(Qt.Unchecked)
+        try:
+            saved_item.setBackground(color)
+            brightness = 0.299 * color.red() + 0.587 * color.green() + 0.114 * color.blue()
+            saved_item.setForeground(Qt.black if brightness > 128 else Qt.white)
+        except Exception:
+            pass
+        self.savedMasksList.addItem(saved_item)
+        QMessageBox.information(self, "Saved", f"Saved '{base_name}' as a protected mask.")
+
+    def show_saved_context_menu(self, position):
+        """Context menu for the Saved Masks list."""
+        item = self.savedMasksList.itemAt(position)
+        if item is None:
+            return
+        menu = QMenu()
+        change_color_action = menu.addAction("Change Color")
+        rename_action = menu.addAction("Rename")
+        remove_action = menu.addAction("Remove from Saved")
+        export_action = menu.addAction("Export")
+        export_stats_action = menu.addAction("Export Intensity Stats (CSV)")
+        action = menu.exec_(self.savedMasksList.mapToGlobal(position))
+        if action == change_color_action:
+            self.change_saved_mask_color(item)
+        elif action == rename_action:
+            self.rename_saved_mask(item)
+        elif action == remove_action:
+            self.remove_saved_mask(item)
+        elif action == export_action:
+            self.export_single_saved_mask(item)
+        elif action == export_stats_action:
+            try:
+                sid = int(item.data(Qt.UserRole))
+            except Exception:
+                sid = None
+            self.export_intensity_stats(saved_id=sid)
+
+    def toggle_saved_visibility(self, item: QListWidgetItem):
+        saved_id = int(item.data(Qt.UserRole)) if item is not None else None
+        if saved_id is None:
+            return
+        if item.checkState() == Qt.Checked:
+            self._saved_visible.add(saved_id)
+        else:
+            self._saved_visible.discard(saved_id)
+        # Refresh display
+        self.show_label_image(self._clustered_image, self._num_labels)
+
+    def rename_saved_mask(self, item: QListWidgetItem):
+        saved_id = int(item.data(Qt.UserRole))
+        mask, color, current_name = self._saved_masks.get(saved_id, (None, None, None))
+        if mask is None:
+            return
+        new_name, ok = QInputDialog.getText(self, "Rename Saved Mask", "Enter a new name:", text=str(current_name))
+        if not ok:
+            return
+        new_name = new_name.strip()
+        if not new_name:
+            QMessageBox.warning(self, "Invalid Name", "Saved mask name cannot be empty.")
+            return
+        # Enforce uniqueness across saved masks
+        existing_names = {entry[2] for entry in self._saved_masks.values()} - {current_name}
+        if new_name in existing_names:
+            bump = 2
+            base = new_name
+            while f"{base} [{bump}]" in existing_names:
+                bump += 1
+            new_name = f"{base} [{bump}]"
+        self._saved_masks[saved_id] = (mask, color, new_name)
+        item.setText(new_name)
+
+    def change_saved_mask_color(self, item: QListWidgetItem):
+        saved_id = int(item.data(Qt.UserRole))
+        mask, color, name = self._saved_masks.get(saved_id, (None, None, None))
+        if mask is None:
+            return
+        new_color = QColorDialog.getColor(color, self, f"Select Color for {name}")
+        if not new_color.isValid():
+            return
+        self._saved_masks[saved_id] = (mask, new_color, name)
+        item.setBackground(new_color)
+        brightness = 0.299 * new_color.red() + 0.587 * new_color.green() + 0.114 * new_color.blue()
+        item.setForeground(Qt.black if brightness > 128 else Qt.white)
+        # Clear saved overlay cache
+        self.saved_mask_overlays.clear()
+        self.show_label_image(self._clustered_image, self._num_labels)
+
+    def remove_saved_mask(self, item: QListWidgetItem):
+        saved_id = int(item.data(Qt.UserRole))
+        # Remove overlay if present
+        if saved_id in self.saved_overlay_items:
+            try:
+                if self.saved_overlay_items[saved_id].scene() == self.displayImage:
+                    self.displayImage.removeItem(self.saved_overlay_items[saved_id])
+            except Exception:
+                pass
+            self.saved_overlay_items.pop(saved_id, None)
+        # Remove from data structures
+        self._saved_masks.pop(saved_id, None)
+        self._saved_visible.discard(saved_id)
+        # Remove from UI
+        row = self.savedMasksList.row(item)
+        self.savedMasksList.takeItem(row)
+        # Clear cache and refresh
+        self.saved_mask_overlays.clear()
+        self.show_label_image(self._clustered_image, self._num_labels)
+
+    def export_single_saved_mask(self, item: QListWidgetItem):
+        saved_id = int(item.data(Qt.UserRole))
+        self._export_saved_mask_ids([saved_id])
+
+    def export_saved_masks(self):
+        if not self._saved_visible:
+            QMessageBox.warning(self, "No Saved Masks Selected", "Please check one or more saved masks to export.")
+            return
+        self._export_saved_mask_ids(list(self._saved_visible))
+
+    def export_intensity_stats(self, saved_id: int | None = None):
+        """
+        Export pixel intensity statistics under a selected Saved Mask for selected raw images as CSV.
+
+        Columns: image_name, mask_id, mask_name, mean, median, min, max, range
+        """
+        # Ensure images loaded
+        try:
+            if self._image_set is None or self._image_set.num_images == 0:
+                QMessageBox.warning(self, "No Images Loaded", "Please load raw images before exporting statistics.")
+                return
+        except Exception:
+            QMessageBox.warning(self, "Image Set Error", "The image set is not properly initialized. Please load images first.")
+            return
+
+        # Ensure there is at least one saved mask
+        if not self._saved_masks:
+            QMessageBox.warning(self, "No Saved Masks", "There are no saved masks available. Save a mask first.")
+            return
+
+        # Determine which saved mask to use
+        sid = None
+        if isinstance(saved_id, int):
+            sid = int(saved_id)
+        else:
+            # Try current selection in the Saved Masks list
+            current_item = self.savedMasksList.currentItem() if hasattr(self, 'savedMasksList') else None
+            sid = int(current_item.data(Qt.UserRole)) if current_item is not None else None
+        if sid is None or sid not in self._saved_masks:
+            # Prompt user to pick one from names
+            items = []
+            id_for_row = []
+            for k, (_mask, _color, nm) in self._saved_masks.items():
+                items.append(f"{k}: {nm}")
+                id_for_row.append(int(k))
+            choice, ok = QInputDialog.getItem(self, "Select Saved Mask", "Saved Mask:", items, 0, False)
+            if not ok:
+                return
+            # Parse id from the prefix before ':'
+            try:
+                sid = int(choice.split(":", 1)[0].strip())
+            except Exception:
+                QMessageBox.warning(self, "Selection Error", "Could not determine selected saved mask.")
+                return
+
+        entry = self._saved_masks.get(int(sid))
+        if not entry:
+            QMessageBox.warning(self, "Mask Error", "Selected saved mask not found.")
+            return
+        roi_mask, _color, mask_name = entry
+
+        # Validate mask shape against images
+        try:
+            img_h, img_w = self._image_set.image_shape
+        except Exception:
+            QMessageBox.warning(self, "Image Set Error", "Image shapes are unavailable. Reload images and try again.")
+            return
+        if roi_mask.shape != (img_h, img_w):
+            QMessageBox.warning(self, "Shape Mismatch", f"Saved mask shape {roi_mask.shape} does not match image shape {(img_h, img_w)}.")
+            return
+
+        # Prompt to select which images to include
+        select_dlg = ImageSelectDlg(self.fileNameList, self._image_set, checked=True)
+        select_dlg.setModal(True)
+        select_dlg.exec_()
+        selected_mask = getattr(select_dlg, 'selected_mask', None)
+        if selected_mask is None or not np.any(selected_mask):
+            QMessageBox.information(self, "No Images Selected", "No images were selected for export.")
+            return
+
+        # Prompt for CSV save path
+        csv_path, _ = QFileDialog.getSaveFileName(self, "Save CSV", "", "CSV Files (*.csv);")
+        if not csv_path:
+            return
+        if not csv_path.lower().endswith('.csv'):
+            csv_path += '.csv'
+
+        # Compute statistics and write CSV
+        images = self._image_set.images  # shape (N,H,W), float
+        header = ["image_name", "mask_id", "mask_name", "mean", "median", "min", "max", "range"]
+        empty_mask = not bool(np.any(roi_mask))
+        try:
+            with open(csv_path, mode='w', newline='') as f:
+                writer = csv.writer(f)
+                writer.writerow(header)
+                for idx, use in enumerate(selected_mask):
+                    if not bool(use):
+                        continue
+                    img = images[idx]
+                    values = img[roi_mask]
+                    if values.size == 0 or empty_mask:
+                        mean = median = vmin = vmax = vrange = float('nan')
+                    else:
+                        # Ensure finite values
+                        vals = values[np.isfinite(values)]
+                        if vals.size == 0:
+                            mean = median = vmin = vmax = vrange = float('nan')
+                        else:
+                            vmin = float(np.min(vals))
+                            vmax = float(np.max(vals))
+                            mean = float(np.mean(vals))
+                            median = float(np.median(vals))
+                            vrange = float(vmax - vmin)
+                    writer.writerow([self.fileNameList[idx], int(sid), str(mask_name), mean, median, vmin, vmax, vrange])
+        except Exception as e:
+            QMessageBox.critical(self, "Export Failed", f"Failed to write CSV: {e}")
+            return
+
+        QMessageBox.information(self, "Success", f"Intensity statistics exported to {csv_path}")
+
+    def _export_saved_mask_ids(self, saved_ids: list[int]):
+        output_dir = QFileDialog.getExistingDirectory(self, "Select Directory to Save Masks")
+        if not output_dir:
+            return
+        file_format = self.exportFormatCombo.currentText().lower()
+        progress = QProgressDialog("Exporting saved masks...", "Cancel", 0, len(saved_ids), self)
+        progress.setWindowModality(Qt.WindowModal)
+        progress.setMinimumDuration(500)
+        for i, sid in enumerate(saved_ids):
+            if progress.wasCanceled():
+                break
+            entry = self._saved_masks.get(int(sid))
+            if not entry:
+                progress.setValue(i + 1)
+                continue
+            mask, _color, name = entry
+            safe_name = re.sub(r'[^A-Za-z0-9_-]+', '_', name).strip('_') or f"saved_{sid}"
+            output_path = os.path.join(output_dir, f"{safe_name}.{file_format}")
+            try:
+                mask_array = mask.astype(np.uint8) * 255
+                img = Image.fromarray(mask_array, mode='L')
+                img.save(output_path)
+            except Exception as e:
+                print(f"Failed to export saved mask {sid}: {e}")
+            progress.setValue(i + 1)
+        if not progress.wasCanceled():
+            QMessageBox.information(self, "Success", f"Saved masks exported to {output_dir}")
+
     def toggle_cluster_visibility(self, item):
-        cluster_id = int(item.text().split()[-1])
+        cluster_id = int(item.data(Qt.UserRole))
         print(f"Toggling visibility for cluster {cluster_id}, check state: {item.checkState()}")
         if item.checkState() == Qt.Checked:
             self._visible_clusters.add(cluster_id)
-            self._selected_clusters.add(cluster_id)  # Also select for reclustering
-            print(f"Selected cluster {cluster_id} for reclustering")
+            print(f"Showing mask for cluster {cluster_id}")
         else:
             self._visible_clusters.discard(cluster_id)
-            self._selected_clusters.discard(cluster_id)  # Deselect for reclustering
-            print(f"Deselected cluster {cluster_id} from reclustering")
+            print(f"Hiding mask for cluster {cluster_id}")
         self.show_label_image(self._clustered_image, self._num_labels)
 
     def merge_selected_clusters(self):
         """
         Merge selected clusters into a single cluster.
 
-        This method gets the selected clusters from the _selected_clusters set,
-        calls the merge_clusters method in Cluster.py with the selected cluster IDs,
-        and calls the on_cluster_callback method with the new labels and settings.
+        This method gathers the checked clusters in the Cluster Mask Visibility list,
+        calls the merge_clusters method in Cluster.py with those IDs, and invokes
+        the on_cluster_callback with the updated labels/settings.
         """
         if self.clusterview is None or self._masks is None:
             QMessageBox.warning(self, "No Clustering Data", "Please run initial clustering first.")
             return
 
-        if len(self._selected_clusters) < 2:
-            QMessageBox.warning(self, "Insufficient Clusters Selected", "Please select at least two clusters to merge by checking them in the Cluster Mask Visibility list.")
+        # Gather checked cluster ids from the visibility list
+        checked_ids = []
+        for i in range(self.clusterVisibilityList.count()):
+            item = self.clusterVisibilityList.item(i)
+            if item.checkState() == Qt.Checked:
+                checked_ids.append(int(item.data(Qt.UserRole)))
+
+        if len(checked_ids) < 2:
+            QMessageBox.warning(self, "Insufficient Clusters Selected", "Please check at least two clusters to merge in the Cluster Mask Visibility list.")
             return
 
-        # Convert set to list for the merge_clusters method
-        cluster_ids = list(self._selected_clusters)
-
         # Call the merge_clusters method in Cluster.py
-        new_labels, new_settings = self.clusterview.merge_clusters(cluster_ids)
+        new_labels, new_settings = self.clusterview.merge_clusters(checked_ids)
 
         if new_labels is None:
             QMessageBox.warning(self, "Merge Failed", "Failed to merge the selected clusters. Please ensure all selected clusters are valid.")
@@ -741,45 +1181,13 @@ class ImageViewerUi(QMainWindow):
         # Call the callback with the new labels and settings
         self.on_cluster_callback(new_labels, new_settings)
 
-        # Clear selected clusters after processing
-        self._selected_clusters.clear()
-
         # Show success message
-        QMessageBox.information(self, "Merge Successful", f"Successfully merged {len(cluster_ids)} clusters into a single cluster.")
+        QMessageBox.information(self, "Merge Successful", f"Successfully merged {len(checked_ids)} clusters into a single cluster.")
 
     def run_iterative_clustering(self):
-        if self.clusterview is None or self._masks is None:
-            QMessageBox.warning(self, "No Clustering Data", "Please run initial clustering first.")
-            return
-
-        if not self._selected_clusters:
-            QMessageBox.warning(self, "No Clusters Selected", "Please select at least one cluster for reclustering by checking it in the Cluster Mask Visibility list.")
-            return
-
-        try:
-            n_sub_clusters = int(self.subClustersInput.text())
-            if n_sub_clusters < 2:
-                raise ValueError("Number of sub-clusters must be at least 2.")
-        except ValueError:
-            QMessageBox.warning(self, "Invalid Input", "Please enter a valid number of sub-clusters (at least 2).")
-            return
-
-        # Process each selected cluster
-        for cluster_id in self._selected_clusters:
-            mask, _ = self._masks.get(cluster_id, (None, None))
-            if mask is None:
-                print(f"Invalid mask for cluster {cluster_id}, skipping")
-                continue
-
-            new_labels, new_settings = self.clusterview.cluster_on_mask(mask, n_sub_clusters)
-            if new_labels is None:
-                print(f"No pixels in the mask region for cluster {cluster_id}, skipping")
-                continue
-
-            self.on_cluster_callback(new_labels, new_settings)
-
-        # Clear selected clusters after processing
-        self._selected_clusters.clear()
+        # Iterative clustering UI has been removed per user request; method retained for compatibility
+        QMessageBox.information(self, "Iterative Clustering Disabled", "Iterative clustering controls have been removed. Use cluster masks as ROI externally or via future workflows.")
+        return
 
     def undo_clustering(self):
         if self.clusterview and self.clusterview.undo_clustering():
@@ -791,6 +1199,7 @@ class ImageViewerUi(QMainWindow):
         self._mask_opacity = value
         # Clear mask overlay cache to force recompute with new opacity
         self.mask_overlays.clear()
+        self.saved_mask_overlays.clear()
         if self._clustered_image is not None and self._num_labels is not None:
             self.show_label_image(self._clustered_image, self._num_labels)
         else:
@@ -823,8 +1232,15 @@ class ImageViewerUi(QMainWindow):
             if progress.wasCanceled():
                 break
 
+            # Build output path using custom name if available
+            custom_name = self._cluster_names.get(int(cluster_id))
+            if custom_name:
+                safe_name = re.sub(r'[^A-Za-z0-9_-]+', '_', custom_name).strip('_') or f"cluster_{cluster_id}"
+                output_path = os.path.join(output_dir, f"{safe_name}")
+            else:
+                output_path = os.path.join(output_dir, f"cluster_{cluster_id}_mask")
+
             # Use Cluster class to export the mask
-            output_path = os.path.join(output_dir, f"cluster_{cluster_id}_mask")
             success = self.clusterview.export_cluster_mask(cluster_id, output_path, file_format)
 
             if not success:
@@ -871,26 +1287,33 @@ class ImageViewerUi(QMainWindow):
             self.displayImage.addPixmap(pixmap)
             print("Rendered clustered image")
 
-        # Remove overlays for deselected clusters
-        print(f"Before removal: overlay_items = {self.overlay_items.keys()}")
+        # Remove overlays for deselected clusters (live)
         clusters_to_remove = set(self.overlay_items.keys()) - self._visible_clusters
-        print(f"Clusters to remove: {clusters_to_remove}")
         for cluster_id in clusters_to_remove:
             if cluster_id in self.overlay_items:
                 item = self.overlay_items[cluster_id]
                 try:
                     if item.scene() == self.displayImage:
                         self.displayImage.removeItem(item)
-                        print(f"Removed overlay for cluster {cluster_id}")
-                    else:
-                        print(f"Skipping removal of cluster {cluster_id}: item is not in the current scene")
-                except Exception as e:
-                    print(f"Error removing overlay for cluster {cluster_id}: {e}")
+                except Exception:
+                    pass
                 finally:
                     del self.overlay_items[cluster_id]
-        print(f"After removal: overlay_items = {self.overlay_items.keys()}")
 
-        # Handle mask overlays for visible clusters
+        # Remove overlays for deselected saved masks
+        saved_to_remove = set(self.saved_overlay_items.keys()) - self._saved_visible
+        for sid in saved_to_remove:
+            if sid in self.saved_overlay_items:
+                item = self.saved_overlay_items[sid]
+                try:
+                    if item.scene() == self.displayImage:
+                        self.displayImage.removeItem(item)
+                except Exception:
+                    pass
+                finally:
+                    del self.saved_overlay_items[sid]
+
+        # Handle mask overlays for visible live clusters
         if self._masks and self._visible_clusters:
             first_mask, _ = next(iter(self._masks.values()))
             height, width = first_mask.shape
@@ -899,7 +1322,6 @@ class ImageViewerUi(QMainWindow):
             if self.clusterview is not None:
                 scale_factor = self.clusterview.calculate_optimal_scale_factor(height, width)
             else:
-                # Fallback if clusterview is None
                 max_pixels = 500000
                 scale_factor = np.sqrt(max_pixels / (height * width)) if height * width > max_pixels else 1.0
 
@@ -916,7 +1338,6 @@ class ImageViewerUi(QMainWindow):
                     if cluster_id not in self.overlay_items:
                         item = self.displayImage.addPixmap(overlay_pixmap)
                         self.overlay_items[cluster_id] = item
-                        print(f"Reused cached overlay for cluster {cluster_id}")
                     continue
 
                 mask, color = self._masks.get(cluster_id, (None, None))
@@ -926,13 +1347,12 @@ class ImageViewerUi(QMainWindow):
                 # Create mask overlay
                 if self.clusterview is not None:
                     overlay = self.clusterview.create_mask_overlay(
-                        mask, color, self._mask_opacity, 
+                        mask, color, self._mask_opacity,
                         target_width=new_width, target_height=new_height
                     )
                 else:
-                    # Fallback if clusterview is None
                     if new_width != width or new_height != height:
-                        mask_small = cv2.resize(mask.astype(np.uint8), (new_width, new_height), 
+                        mask_small = cv2.resize(mask.astype(np.uint8), (new_width, new_height),
                                               interpolation=cv2.INTER_NEAREST).astype(bool)
                     else:
                         mask_small = mask
@@ -941,32 +1361,87 @@ class ImageViewerUi(QMainWindow):
                     overlay.fill(Qt.transparent)
 
                     mask_data = np.zeros((new_height, new_width, 4), dtype=np.uint8)
-                    mask_data[mask_small, 0] = color.red()
+                    mask_data[mask_small, 0] = color.blue()
                     mask_data[mask_small, 1] = color.green()
-                    mask_data[mask_small, 2] = color.blue()
+                    mask_data[mask_small, 2] = color.red()
                     mask_data[mask_small, 3] = self._mask_opacity
 
                     overlay_data = mask_data.tobytes()
                     overlay = QImage(overlay_data, new_width, new_height, QImage.Format_ARGB32)
 
-                # Create and cache pixmap
                 overlay_pixmap = QPixmap.fromImage(overlay).scaled(2000, 5000, Qt.KeepAspectRatio)
                 self.mask_overlays[cache_key] = overlay_pixmap
 
-                # Remove existing overlay if present
                 if cluster_id in self.overlay_items:
                     try:
                         if self.overlay_items[cluster_id].scene() == self.displayImage:
                             self.displayImage.removeItem(self.overlay_items[cluster_id])
-                        else:
-                            print(f"Skipping removal of existing overlay for cluster {cluster_id}: item is not in the current scene")
-                    except Exception as e:
-                        print(f"Error removing existing overlay for cluster {cluster_id}: {e}")
+                    except Exception:
+                        pass
 
-                # Add new overlay
                 item = self.displayImage.addPixmap(overlay_pixmap)
                 self.overlay_items[cluster_id] = item
-                print(f"Computed and cached overlay for cluster {cluster_id}")
+
+        # Now render saved masks above live masks
+        if self._saved_masks and self._saved_visible:
+            # infer shape from any saved mask
+            any_entry = next(iter(self._saved_masks.values()))
+            smask = any_entry[0]
+            height, width = smask.shape
+            if self.clusterview is not None:
+                scale_factor = self.clusterview.calculate_optimal_scale_factor(height, width)
+            else:
+                max_pixels = 500000
+                scale_factor = np.sqrt(max_pixels / (height * width)) if height * width > max_pixels else 1.0
+            if scale_factor < 1.0:
+                new_height = int(height * scale_factor)
+                new_width = int(width * scale_factor)
+            else:
+                new_height, new_width = height, width
+
+            for sid in list(self._saved_visible):
+                entry = self._saved_masks.get(int(sid))
+                if not entry:
+                    continue
+                mask, color, _name = entry
+                cache_key = (int(sid), self._mask_opacity, new_width, new_height)
+                if cache_key in self.saved_mask_overlays:
+                    overlay_pixmap = self.saved_mask_overlays[cache_key]
+                    if sid not in self.saved_overlay_items:
+                        item = self.displayImage.addPixmap(overlay_pixmap)
+                        self.saved_overlay_items[sid] = item
+                    continue
+                # Create overlay
+                if self.clusterview is not None:
+                    overlay = self.clusterview.create_mask_overlay(
+                        mask, color, self._mask_opacity,
+                        target_width=new_width, target_height=new_height
+                    )
+                else:
+                    if new_width != width or new_height != height:
+                        mask_small = cv2.resize(mask.astype(np.uint8), (new_width, new_height),
+                                              interpolation=cv2.INTER_NEAREST).astype(bool)
+                    else:
+                        mask_small = mask
+                    overlay = QImage(new_width, new_height, QImage.Format_ARGB32)
+                    overlay.fill(Qt.transparent)
+                    mask_data = np.zeros((new_height, new_width, 4), dtype=np.uint8)
+                    mask_data[mask_small, 0] = color.blue()
+                    mask_data[mask_small, 1] = color.green()
+                    mask_data[mask_small, 2] = color.red()
+                    mask_data[mask_small, 3] = self._mask_opacity
+                    overlay_data = mask_data.tobytes()
+                    overlay = QImage(overlay_data, new_width, new_height, QImage.Format_ARGB32)
+                overlay_pixmap = QPixmap.fromImage(overlay).scaled(2000, 5000, Qt.KeepAspectRatio)
+                self.saved_mask_overlays[cache_key] = overlay_pixmap
+                if sid in self.saved_overlay_items:
+                    try:
+                        if self.saved_overlay_items[sid].scene() == self.displayImage:
+                            self.displayImage.removeItem(self.saved_overlay_items[sid])
+                    except Exception:
+                        pass
+                item = self.displayImage.addPixmap(overlay_pixmap)
+                self.saved_overlay_items[sid] = item
 
         self.adjustSize()
 


### PR DESCRIPTION
Removed iterative clustering, streamlined into cluster menu.  

Initiated export of mask/img data as stats.  

Repaired "reset viewer."  

Repaired color alignment.  

Created a "live masks" viewer and "saved masks" viewer to preserve masks after iterative clustering.  

Saved masks are available for creating cluster ROI's for both k-means and ISODATA.  ISODATA clustering appears to be clustering 
on ROI, and new cluster masks labels incorporate genealogy. 

"Change Color," "Rename," "Export," and "Save" added to context menu of each cluster label. 